### PR TITLE
Add Bungeecord support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,5 +14,6 @@ dependencies {
     implementation(project(":core"))
     implementation(project(":paper"))
     implementation(project(":velocity"))
-    implementation(project(":waterfall"))
+    // implementation(project(":waterfall"))
+    implementation(project(":bungeecord"))
 }

--- a/bungeecord/.gitignore
+++ b/bungeecord/.gitignore
@@ -1,0 +1,42 @@
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/bungeecord/build.gradle.kts
+++ b/bungeecord/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    id("java")
+}
+
+group = "com.origamimc"
+version = "1.0.0"
+
+repositories {
+    mavenCentral()
+    maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
+}
+
+dependencies {
+    implementation("org.jetbrains:annotations:24.0.0")
+    testImplementation(platform("org.junit:junit-bom:5.9.1"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    compileOnly("org.slf4j:slf4j-jdk14:2.0.9")
+    compileOnly("net.md-5:bungeecord-api:1.20-R0.1")
+    compileOnly(project(":core"))
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/bungeecord/src/main/java/com/origamimc/BungeeLogger.java
+++ b/bungeecord/src/main/java/com/origamimc/BungeeLogger.java
@@ -1,0 +1,26 @@
+package com.origamimc;
+
+public class BungeeLogger implements Logger {
+
+    private final java.util.logging.Logger logger;
+
+    public BungeeLogger(java.util.logging.Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public void info(String message) {
+        logger.info(message);
+    }
+
+    @Override
+    public void warn(String message) {
+        logger.warning(message);
+    }
+
+    @Override
+    public void error(String message) {
+        logger.severe(message);
+    }
+
+}

--- a/bungeecord/src/main/java/com/origamimc/WaterfallLogger.java
+++ b/bungeecord/src/main/java/com/origamimc/WaterfallLogger.java
@@ -1,0 +1,26 @@
+package com.origamimc;
+
+public class WaterfallLogger implements Logger {
+
+    private final org.slf4j.Logger logger;
+
+    public WaterfallLogger(org.slf4j.Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public void info(String message) {
+        logger.info(message);
+    }
+
+    @Override
+    public void warn(String message) {
+        logger.warn(message);
+    }
+
+    @Override
+    public void error(String message) {
+        logger.error(message);
+    }
+
+}

--- a/bungeecord/src/main/java/com/origamimc/commands/BungeeOrigamiCommands.java
+++ b/bungeecord/src/main/java/com/origamimc/commands/BungeeOrigamiCommands.java
@@ -1,0 +1,31 @@
+package com.origamimc.commands;
+
+import com.origamimc.main.BungeeOrigamiMain;
+import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.api.connection.ConnectedPlayer;
+import net.md_5.bungee.api.plugin.Command;
+import net.md_5.bungee.api.plugin.TabExecutor;
+
+@SuppressWarnings("unused")
+public class BungeeOrigamiCommands extends Command implements OrigamiCommands, TabExecutor {
+    public BungeeOrigamiCommands(String name, String permission, String... aliases) {
+        super(name, permission, aliases);
+    }
+
+    @Override
+    public void execute(CommandSender sender, String[] args) {
+        OrigamiPermissionHolder permissionHolder;
+        if (sender instanceof ConnectedPlayer connectedPlayer) {
+            permissionHolder = new BungeeOrigamiPermissionHolder(connectedPlayer);
+        } else permissionHolder = OrigamiPermissionHolder.consolePermissions;
+        if (runCommand(args, BungeeOrigamiMain.getOrigamiInstances(), permissionHolder)) {
+            sender.sendMessage(TextComponent.fromLegacyText("Command usage: /origami <instance> <input>"));
+        }
+    }
+
+    @Override
+    public Iterable<String> onTabComplete(CommandSender sender, String[] args) {
+        return getSuggestions(args, BungeeOrigamiMain.getOrigamiInstances());
+    }
+}

--- a/bungeecord/src/main/java/com/origamimc/commands/BungeeOrigamiPermissionHolder.java
+++ b/bungeecord/src/main/java/com/origamimc/commands/BungeeOrigamiPermissionHolder.java
@@ -1,0 +1,16 @@
+package com.origamimc.commands;
+
+import net.md_5.bungee.api.connection.ConnectedPlayer;
+
+public class BungeeOrigamiPermissionHolder extends OrigamiPermissionHolder {
+    private final ConnectedPlayer player;
+
+    public BungeeOrigamiPermissionHolder(ConnectedPlayer player) {
+        this.player = player;
+    }
+
+    @Override
+    public boolean hasPermission(String permission) {
+        return player.hasPermission(permission);
+    }
+}

--- a/bungeecord/src/main/java/com/origamimc/configurations/BungeeOrigamiConfiguration.java
+++ b/bungeecord/src/main/java/com/origamimc/configurations/BungeeOrigamiConfiguration.java
@@ -1,0 +1,38 @@
+package com.origamimc.configurations;
+
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Map;
+
+public class BungeeOrigamiConfiguration extends OrigamiConfiguration {
+    private Map<String, Object> node;
+    private static final Yaml yaml = new Yaml();
+    @Override
+    @SuppressWarnings("unchecked")
+    public Object get(String path) {
+        String[] data = path.split("\\.");
+        int i = 0;
+        Map<String, Object> search = node;
+        for (String s : data) {
+            i++;
+            if (i < data.length) {
+                if (search.get(s) == null) return null;
+                search = (Map<String, Object>) search.get(s);
+            } else return search.get(s);
+            node.get(s);
+        }
+        return null;
+    }
+
+    @Override
+    public void load(File file) {
+        try {
+            node = yaml.load(new FileInputStream(file));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/bungeecord/src/main/java/com/origamimc/main/BungeeOrigamiMain.java
+++ b/bungeecord/src/main/java/com/origamimc/main/BungeeOrigamiMain.java
@@ -1,0 +1,122 @@
+package com.origamimc.main;
+
+import com.origamimc.OrigamiInstance;
+import com.origamimc.Logger;
+import com.origamimc.BungeeLogger;
+import com.origamimc.WaterfallLogger;
+import com.origamimc.commands.BungeeOrigamiCommands;
+import com.origamimc.configurations.BungeeOrigamiConfiguration;
+import net.md_5.bungee.api.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+public class BungeeOrigamiMain extends Plugin {
+    private static final Map<String, OrigamiInstance> origamiInstances = new HashMap<>();
+
+    public static Map<String, OrigamiInstance> getOrigamiInstances() {
+        return origamiInstances;
+    }
+
+    public Logger logger;
+    private static BungeeOrigamiMain instance;
+    private File dataDirectory;
+
+    @Override
+    public void onEnable() {
+        instance = this;
+
+        this.dataDirectory = getDataFolder();
+
+        try {
+            // try to assign waterfall logger
+            Method getSLF4JLoggerMethod = this.getClass().getMethod("getSLF4JLogger");
+            if (getSLF4JLoggerMethod != null) {
+                getProxy().getPluginManager().registerCommand(this, new BungeeOrigamiCommands(
+                        "origami",
+                        "origami.command",
+                        "origami-waterfall"));
+                this.logger = new WaterfallLogger((org.slf4j.Logger) getSLF4JLoggerMethod.invoke(this));
+            }
+        } catch (NoSuchMethodException e) {
+            getProxy().getPluginManager().registerCommand(this, new BungeeOrigamiCommands(
+                    "origami",
+                    "origami.command",
+                    "origami-bungee"));
+            this.logger = new BungeeLogger(getLogger());
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            // Handle reflection errors during method invocation
+            throw new RuntimeException("Error invoking getSLF4JLogger method.", e);
+        } catch (Exception ex) {
+            // Catch any other unexpected exceptions
+            throw new RuntimeException("Error initializing logger", ex);
+        }
+        OrigamiSetup setup = new BungeeOrigamiSetup();
+
+        File programsFolder = new File(dataDirectory, "programs");
+        boolean ignored = programsFolder.mkdirs();
+        File[] files = programsFolder.listFiles();
+        if (files != null) {
+            for (File program : files) {
+                if (program.isDirectory()) {
+                    origamiInstances.put(program.getName().toLowerCase(), new OrigamiInstance(
+                            program,
+                            program.getName(),
+                            new BungeeOrigamiConfiguration(),
+                            setup));
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onDisable() {
+        for (OrigamiInstance origamiInstance : BungeeOrigamiMain.getOrigamiInstances().values()) {
+            origamiInstance.stop(false);
+        }
+    }
+
+    public static BungeeOrigamiMain getInstance() {
+        return instance;
+    }
+
+    public static class BungeeOrigamiSetup extends OrigamiSetup {
+
+        @Override
+        public void saveResource(String resource) {
+            File file = new File(BungeeOrigamiMain.getInstance().dataDirectory, resource);
+            boolean ignored1 = file.getParentFile().mkdirs();
+            try {
+                boolean ignored2 = file.createNewFile();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            try (FileOutputStream outputStream = new FileOutputStream(file)) {
+                for (byte b : getResource(resource).readAllBytes()) {
+                    outputStream.write(b);
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public @NotNull InputStream getResource(String resource) {
+            InputStream stream = getClass().getClassLoader().getResourceAsStream(resource);
+            assert stream != null;
+            return stream;
+        }
+
+        @Override
+        public @NotNull Logger getLogger() {
+            return BungeeOrigamiMain.getInstance().logger;
+        }
+    }
+}

--- a/bungeecord/src/main/resources/bungee.yml
+++ b/bungeecord/src/main/resources/bungee.yml
@@ -1,0 +1,5 @@
+name: Origami
+main: com.origamimc.main.BungeeOrigamiMain
+version: 1.0.0
+author: cometcake575
+description: Run other jar files inside of Paper, Velocity or Waterfall servers

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -13,7 +13,6 @@ dependencies {
     testImplementation(platform("org.junit:junit-bom:5.9.1"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     compileOnly("org.jetbrains:annotations:23.0.0")
-    compileOnly("org.slf4j:slf4j-jdk14:2.0.9")
 }
 
 tasks.test {

--- a/core/src/main/java/com/origamimc/Logger.java
+++ b/core/src/main/java/com/origamimc/Logger.java
@@ -1,0 +1,10 @@
+package com.origamimc;
+
+public interface Logger {
+    void info(String message);
+
+    void warn(String message);
+
+    void error(String message);
+
+}

--- a/core/src/main/java/com/origamimc/main/OrigamiSetup.java
+++ b/core/src/main/java/com/origamimc/main/OrigamiSetup.java
@@ -1,10 +1,11 @@
 package com.origamimc.main;
 
 import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
 
 import java.io.InputStream;
 import java.util.logging.Level;
+
+import com.origamimc.Logger;
 
 public abstract class OrigamiSetup {
     public OrigamiSetup() {

--- a/paper/src/main/java/com/origamimc/PaperLogger.java
+++ b/paper/src/main/java/com/origamimc/PaperLogger.java
@@ -1,0 +1,26 @@
+package com.origamimc;
+
+public class PaperLogger implements Logger {
+
+    private final org.slf4j.Logger logger;
+
+    public PaperLogger(org.slf4j.Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public void info(String message) {
+        logger.info(message);
+    }
+
+    @Override
+    public void warn(String message) {
+        logger.warn(message);
+    }
+
+    @Override
+    public void error(String message) {
+        logger.error(message);
+    }
+
+}

--- a/paper/src/main/java/com/origamimc/main/PaperOrigamiMain.java
+++ b/paper/src/main/java/com/origamimc/main/PaperOrigamiMain.java
@@ -1,6 +1,8 @@
 package com.origamimc.main;
 
 import com.origamimc.OrigamiInstance;
+import com.origamimc.Logger;
+import com.origamimc.PaperLogger;
 import com.origamimc.commands.PaperOrigamiCommands;
 import com.origamimc.configurations.PaperOrigamiConfiguration;
 import org.bukkit.command.*;
@@ -10,7 +12,6 @@ import org.jetbrains.annotations.NotNull;
 import java.io.File;
 import java.io.InputStream;
 import java.util.*;
-import org.slf4j.Logger;
 
 public class PaperOrigamiMain extends JavaPlugin implements CommandExecutor, TabCompleter {
 
@@ -26,9 +27,13 @@ public class PaperOrigamiMain extends JavaPlugin implements CommandExecutor, Tab
         return instance;
     }
 
+    public Logger logger;
+
     @Override
     public void onEnable() {
         instance = this;
+
+        this.logger = new PaperLogger(this.getSLF4JLogger());
         OrigamiSetup setup = new PaperOrigamiSetup();
         saveResource("examples/default-example.yml", true);
         saveResource("examples/discordbot-example.yml", true);
@@ -77,7 +82,7 @@ public class PaperOrigamiMain extends JavaPlugin implements CommandExecutor, Tab
 
         @Override
         public @NotNull Logger getLogger() {
-            return PaperOrigamiMain.getInstance().getSLF4JLogger();
+            return PaperOrigamiMain.getInstance().logger;
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,4 +2,5 @@ rootProject.name = "Origami"
 include("core")
 include("paper")
 include("velocity")
-include("waterfall")
+// include("waterfall") // bungeecord and waterfall code is identical
+include("bungeecord")

--- a/velocity/src/main/java/com/origamimc/VelocityLogger.java
+++ b/velocity/src/main/java/com/origamimc/VelocityLogger.java
@@ -1,0 +1,26 @@
+package com.origamimc;
+
+public class VelocityLogger implements Logger {
+
+    private final org.slf4j.Logger logger;
+
+    public VelocityLogger(org.slf4j.Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public void info(String message) {
+        logger.info(message);
+    }
+
+    @Override
+    public void warn(String message) {
+        logger.warn(message);
+    }
+
+    @Override
+    public void error(String message) {
+        logger.error(message);
+    }
+
+}

--- a/velocity/src/main/java/com/origamimc/main/VelocityOrigamiMain.java
+++ b/velocity/src/main/java/com/origamimc/main/VelocityOrigamiMain.java
@@ -1,6 +1,8 @@
 package com.origamimc.main;
 
 import com.origamimc.OrigamiInstance;
+import com.origamimc.Logger;
+import com.origamimc.VelocityLogger;
 import com.origamimc.commands.VelocityOrigamiCommands;
 import com.origamimc.configurations.VelocityOrigamiConfiguration;
 import com.velocitypowered.api.event.Subscribe;
@@ -9,7 +11,6 @@ import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.ProxyServer;
 import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
 
 import javax.inject.Inject;
 import java.io.*;
@@ -35,7 +36,7 @@ public class VelocityOrigamiMain {
     private static VelocityOrigamiMain instance;
     private final Path dataDirectory;
     @Inject
-    public VelocityOrigamiMain(ProxyServer server, Logger logger, @DataDirectory Path dataDirectory) {
+    public VelocityOrigamiMain(ProxyServer server, org.slf4j.Logger logger, @DataDirectory Path dataDirectory) {
         instance = this;
 
         this.dataDirectory = dataDirectory;
@@ -43,7 +44,7 @@ public class VelocityOrigamiMain {
         server.getCommandManager().register("origami", new VelocityOrigamiCommands(), "origami-velocity");
 
 
-        this.logger = logger;
+        this.logger = new VelocityLogger(logger);
         OrigamiSetup setup = new VelocityOrigamiSetup();
 
         File programsFolder = new File(dataDirectory.toFile(), "programs");

--- a/waterfall/src/main/java/com/origamimc/WaterfallLogger.java
+++ b/waterfall/src/main/java/com/origamimc/WaterfallLogger.java
@@ -1,0 +1,26 @@
+package com.origamimc;
+
+public class WaterfallLogger implements Logger {
+
+    private final org.slf4j.Logger logger;
+
+    public WaterfallLogger(org.slf4j.Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public void info(String message) {
+        logger.info(message);
+    }
+
+    @Override
+    public void warn(String message) {
+        logger.warn(message);
+    }
+
+    @Override
+    public void error(String message) {
+        logger.error(message);
+    }
+
+}

--- a/waterfall/src/main/java/com/origamimc/main/WaterfallOrigamiMain.java
+++ b/waterfall/src/main/java/com/origamimc/main/WaterfallOrigamiMain.java
@@ -1,11 +1,12 @@
 package com.origamimc.main;
 
 import com.origamimc.OrigamiInstance;
+import com.origamimc.Logger;
+import com.origamimc.WaterfallLogger;
 import com.origamimc.commands.WaterfallOrigamiCommands;
 import com.origamimc.configurations.WaterfallOrigamiConfiguration;
 import net.md_5.bungee.api.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -37,7 +38,7 @@ public class WaterfallOrigamiMain extends Plugin {
                 "origami-waterfall"
         ));
 
-        this.logger = getSLF4JLogger();
+        this.logger = new WaterfallLogger(getSLF4JLogger());
         OrigamiSetup setup = new WaterfallOrigamiSetup();
 
         File programsFolder = new File(dataDirectory, "programs");


### PR DESCRIPTION
This PR includes:  
- Wrapping the logger to support platforms that use different logger instances (e.g., SLF4J and `java.util.logging`).  
- Adding support for BungeeCord.  

Notes:  
- The BungeeCord code is identical to the Waterfall code but uses the BungeeCord API and logger.  
- The BungeeCord implementation also attempts to assign the Waterfall `SLF4JLogger` where possible.  
- Not sure what to do with the Waterfall code, as it's now the same as the BungeeCord code (this PR favoring BungeeCord for compilation).  
